### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Recommended Terminal Emulator: [kitty](https://sw.kovidgoyal.net/kitty/binary/)
 
 ```
 git clone https://github.com/datavorous/dunefetch
-cd dunefetch-main
-cd dunefetch-main
+cd dunefetch
 python -m venv .venv
 source .venv/bin/activate
 pip install .


### PR DESCRIPTION
setup.py and stuff is in the root but you were going deep one more directory.
the clone of repo's name is dunefetch and not dunefetch-main